### PR TITLE
chore: format infix operation with match

### DIFF
--- a/lib/array.mbt
+++ b/lib/array.mbt
@@ -21,10 +21,11 @@ pub fn to_string(self : L) -> String {
   let arr = self.value
   let x2 = self.shape.rows > 0 && self.shape.cols > 0
   for i = 0
-      i < match x2 {
+      i <
+     (match x2 {
        false => 1
        true => self.shape.cols
-     }
+     })
       i = i + 1 {
     if x2 {
       result = result + "["

--- a/lib/matrix.mbt
+++ b/lib/matrix.mbt
@@ -27,14 +27,8 @@ pub fn dot(a : L, b : L) -> L {
   let m = a.shape.rows
   let n = a.shape.cols
   let p = b.shape.cols
-  let arr = a.value;
-  let c = multiplyMatrices(
-    arr.map(to_double),
-    arr.map(to_double),
-    m,
-    n,
-    p,
-  )
+  let arr = a.value
+  let c = multiplyMatrices(arr.map(to_double), arr.map(to_double), m, n, p)
   let cL = from_array(c)
   cL.shape = { rows: m, cols: p }
   cL
@@ -44,7 +38,7 @@ pub fn L::transpose(a : L) -> L {
   let m = a.shape.rows
   let n = a.shape.cols
   let b = Array::make(n * m, 0.0)
-  let arr = a.value;
+  let arr = a.value
   for i = 0; i < m; i = i + 1 {
     for j = 0; j < n; j = j + 1 {
       let x = j * m + i


### PR DESCRIPTION
We are going to disallow the mixed-up usage of match and infix expression (like comparison expression). This means the following code is not valid in a few weeks.

This PR add parentheses to 1 places in your codebase that will be broke by this change.